### PR TITLE
luaHeapAlloc: try to not use osize

### DIFF
--- a/firmware/controllers/lua/lua_heap.cpp
+++ b/firmware/controllers/lua/lua_heap.cpp
@@ -181,6 +181,7 @@ void* luaHeapAlloc(void* /*ud*/, void* optr, size_t osize, size_t nsize) {
     }
 
     if (optr) {
+    	chDbgAssert(osize <= chHeapGetSize(optr), "Lua lost track of allocated mem");
         // An old pointer was passed in. Only free it if we successfully allocated a new one.
         size_t oldSize = chHeapGetSize(optr);
         if (nptr != nullptr) {


### PR DESCRIPTION
> When ptr is not NULL, osize is the size of the block pointed by ptr, that is, the size given when it was allocated or reallocated.
> 
> When ptr is NULL, osize encodes the kind of object that Lua is allocating. osize is any of [LUA_TSTRING](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TSTRING), [LUA_TTABLE](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TTABLE), [LUA_TFUNCTION](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TFUNCTION), [LUA_TUSERDATA](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TUSERDATA), or [LUA_TTHREAD](https://www.lua.org/manual/5.3/manual.html#pdf-LUA_TTHREAD) when (and only when) Lua is creating a new object of that type. When osize is some other value, Lua is allocating memory for something else.

[...]

> When nsize is not zero, the allocator must behave like realloc. The allocator returns NULL if and only if it cannot fulfill the request. Lua assumes that the allocator never fails when osize >= nsize.

will use a bit more of ram, but `chHeapGetSize` should get us the correct sizes, also this prevents the reboot when we use all or more than available ram #8774
